### PR TITLE
Additional a11y improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ These are custom build HTML blocks that you have to enter into the WYSIWYG edito
         <h2><a href="/tickets">Haal hier je ticket!</a></h2>
         <hr />
         <h2><a href="/tickets">Get your ticket here!</a></h2>
-        <a href="/tickets"><img class="tickets aligncenter wp-image-347 size-medium" src="tickets-liggend-small-300x225.png" alt="" width="300" height="225" alt="Haal hier je ticket." /></a>
+        <a href="/tickets"><img class="tickets aligncenter wp-image-347 size-medium" src="tickets-liggend-small-300x225.png" alt="Get your ticket" width="300" height="225" alt="Haal hier je ticket." /></a>
     </div>
 </div>
 ```

--- a/source/styles/320/header.scss
+++ b/source/styles/320/header.scss
@@ -47,7 +47,7 @@ body.has-header-image .site-title, body.has-header-video .site-title, body.has-h
   font-size: 1.1rem;
   margin-bottom: 0;
   display: block;
-  color: #009D4e !important;
+  color: #18883C !important;
   font-family: 'Montserrat', sans-serif;
 }
 

--- a/source/styles/320/links.scss
+++ b/source/styles/320/links.scss
@@ -8,10 +8,7 @@ a {
 
 a:hover, a:active, a:focus {
   color: $blue;
-  text-decoration: underline;
-}
-a:focus {
-  outline: 1;
+  text-decoration: none;
 }
 
 .edit-link {

--- a/source/styles/320/primary-navigation.scss
+++ b/source/styles/320/primary-navigation.scss
@@ -2,9 +2,9 @@
 12.0 Navigation
 --------------------------------------------------------------*/
 .navigation-top {
-  background: #18883C;
-  font-size: 16px;
-  font-size: 1rem;
+  background: #009D4e;
+  font-size: 19px;
+  font-size: 1.1875rem;
   position: relative;
 }
 
@@ -23,7 +23,7 @@
   -webkit-transition: color .2s;
   transition: color .2s;
   font-family: 'Montserrat', sans-serif !important;
-  font-weight: 400;
+  font-weight: 700;
   padding: .75em 2.05em;
   display: block;
   text-decoration: none;

--- a/source/styles/320/primary-navigation.scss
+++ b/source/styles/320/primary-navigation.scss
@@ -2,7 +2,7 @@
 12.0 Navigation
 --------------------------------------------------------------*/
 .navigation-top {
-  background: #009D4e;
+  background: #18883C;
   font-size: 16px;
   font-size: 1rem;
   position: relative;

--- a/source/styles/768/primary-navigation.scss
+++ b/source/styles/768/primary-navigation.scss
@@ -88,7 +88,7 @@
   text-align: center;
 }
 .main-navigation ul {
-  background: #009D4e;
+  background: #18883C;
   padding: 0;
 }
 
@@ -390,7 +390,7 @@
 }
 
 .main-navigation ul {
-  background: #009D4e;
+  background: #18883C;
   padding: 0;
 }
 


### PR DESCRIPTION
**Colour contrast**
- Change 009D4E to 18883C to enhance colour contrast, 009D4E on white has a too low colour contrast to text.

**Link style improvements**
- Removed the  focus outline: 1; as this removes the default browser focus.
- Changed text decoration to none for hover and focus, to give a visual effect, other than colour change.

**Add meaningful alt text to the ticket link**
When an image is sued as link, the alt attribute is used as link text.
This commit adds the alt text Get your ticket to make the ink text meaningful.
